### PR TITLE
refactor CNetworkLinux

### DIFF
--- a/xbmc/network/Network.cpp
+++ b/xbmc/network/Network.cpp
@@ -650,42 +650,6 @@ std::string CNetwork::CanonizeIPv6(const std::string &address)
   return result;
 }
 
-int CNetwork::PrefixLengthIPv6(const std::string &address)
-{
-  struct sockaddr_in6 mask;
-  if (!ConvIPv6(address, &mask))
-    return -1;
-
-  unsigned int m;
-  unsigned int segment_size = 128 / sizeof(mask.sin6_addr.s6_addr);
-  auto segment_tmax = mask.sin6_addr.s6_addr[0];
-  segment_tmax = -1;
-
-  // let's assume mask being ff80:: - in binary form:
-  // 11111111:10000000
-  // as prefix-length is count of leftmost contiguous bits,
-  // we can simply check how many segments are full of bits (0xff).
-  // this * nr_bits in segment + individual bits from the first segment
-  // not full is our prefix-length.
-  for (m = 0;
-       m < sizeof(mask.sin6_addr.s6_addr) && (mask.sin6_addr.s6_addr[m] == segment_tmax);
-       m += 1);
-
-  m *= segment_size;
-  // if we didn't match all segments (prefixlength not /128)
-  if (m < 128)
-  {
-    // we shift left until we get all bits zero,
-    // then we have final length (in this case it is /9)
-    auto leftover_bits = mask.sin6_addr.s6_addr[m / segment_size];
-    do {
-      m++;
-    } while (leftover_bits <<= 1);
-  }
-
-  return m;
-}
-
 uint8_t CNetwork::PrefixLength(const struct sockaddr *netmask)
 {
   uint8_t prefixLength = 0;

--- a/xbmc/network/Network.cpp
+++ b/xbmc/network/Network.cpp
@@ -18,6 +18,7 @@
  *
  */
 
+#include <bitset>
 #include <stdlib.h>
 
 #include <netinet/in.h>
@@ -683,6 +684,33 @@ int CNetwork::PrefixLengthIPv6(const std::string &address)
   }
 
   return m;
+}
+
+uint8_t CNetwork::PrefixLength(const struct sockaddr *netmask)
+{
+  uint8_t prefixLength = 0;
+  switch (netmask->sa_family)
+  {
+    case AF_INET:
+      prefixLength = std::bitset<sizeof(((struct sockaddr_in *) netmask)->sin_addr.s_addr)>(((struct sockaddr_in *) netmask)->sin_addr.s_addr).count();
+      break;
+    case AF_INET6:
+      for (unsigned int i = 0; i < sizeof(((struct sockaddr_in6 *) netmask)->sin6_addr.s6_addr); ++i)
+        prefixLength += std::bitset<sizeof(((struct sockaddr_in6 *) netmask)->sin6_addr.s6_addr)>(((struct sockaddr_in6 *) netmask)->sin6_addr.s6_addr[i]).count();
+      break;
+  }
+  return prefixLength;
+}
+
+bool CNetwork::CompareAddresses(const struct sockaddr * sa, const struct sockaddr * sb)
+{
+  if (sa->sa_family != sb->sa_family)
+    return false;
+  else if (sa->sa_family == AF_INET)
+    return ((struct sockaddr_in *)(sa))->sin_addr.s_addr == ((struct sockaddr_in *)(sb))->sin_addr.s_addr;
+  else if (sa->sa_family == AF_INET6)
+    return (memcmp((char *) &(((struct sockaddr_in6 *)(sa))->sin6_addr), (char *) &(((struct sockaddr_in6 *)(sb))->sin6_addr), sizeof(((struct sockaddr_in6 *)(sa))->sin6_addr))) == 0;
+  return false;
 }
 
 CNetwork::CNetworkUpdater::CNetworkUpdater(void (*watcher)())

--- a/xbmc/network/Network.h
+++ b/xbmc/network/Network.h
@@ -321,20 +321,6 @@ public:
     */
    static std::string CanonizeIPv6(const std::string &address);
 
-   // Networking API calls are providing IPv6 mask information
-   // in the same data structure as address itself (128bit information)
-   // e.g. FFFF:FFFF:FFFF:FFF0:0000:0000:0000:0000
-   // This function returns decimal value specifying how many of the
-   // leftmost contiguous bits of the address comprise
-   // the prefix. This representation is called prefix-length.
-   // Above mask represents prefix of length 60 and formal (and canonised)
-   // address/mask specification would look like this:
-   // 12AB:0:0:CD30::/60
-   // This is also the common preferred way of displaying IPv6 addresses
-   // return 0-128, -1 in case of error (for instance string's notation
-   //                  doesn't comply to standard)
-   static int     PrefixLengthIPv6(const std::string &address);
-
   /*!
    \brief  computes the prefix length for a (IPv4/IPv6) netmask
    \param  struct sockaddr

--- a/xbmc/network/Network.h
+++ b/xbmc/network/Network.h
@@ -335,6 +335,23 @@ public:
    //                  doesn't comply to standard)
    static int     PrefixLengthIPv6(const std::string &address);
 
+  /*!
+   \brief  computes the prefix length for a (IPv4/IPv6) netmask
+   \param  struct sockaddr
+   \return The prefix length of the netmask
+           For IPv4 it can be between 0 and 32
+           For IPv6 it can be between 0 and 128
+   */
+  static uint8_t PrefixLength(const struct sockaddr *netmask);
+
+  /*!
+   \brief  compares two ip addresses (IPv4/IPv6)
+   \param  ip address 1
+   \param  ip address 2
+   \return if the two addresses are the same
+   */
+  static bool CompareAddresses(const struct sockaddr *sa, const struct sockaddr *sb);
+
    /*!
     \brief fully IPv4/IPv6 compatible
            - IPv6 part is limited to addr/mask match only (IPv4 way)

--- a/xbmc/network/linux/NetworkLinux.cpp
+++ b/xbmc/network/linux/NetworkLinux.cpp
@@ -587,12 +587,12 @@ bool CNetworkLinux::PingHostImpl(const std::string &target, unsigned int timeout
   return result == 0;
 }
 
-#if defined(TARGET_DARWIN) || defined(TARGET_FREEBSD)
 bool CNetworkInterfaceLinux::GetHostMacAddress(unsigned long host_ip, std::string& mac)
 {
   if (m_network->GetFirstConnectedFamily() == AF_INET6 || isIPv6())
     return false;
 
+#if defined(TARGET_DARWIN) || defined(TARGET_FREEBSD)
   bool ret = false;
   size_t needed;
   char *buf, *next;
@@ -639,13 +639,7 @@ bool CNetworkInterfaceLinux::GetHostMacAddress(unsigned long host_ip, std::strin
     }
   }
   return ret;
-}
 #else
-bool CNetworkInterfaceLinux::GetHostMacAddress(unsigned long host_ip, std::string& mac)
-{
-  if (m_network->GetFirstConnectedFamily() == AF_INET6 || isIPv6())
-    return false;
-
   struct arpreq areq;
   struct sockaddr_in* sin;
 
@@ -679,8 +673,8 @@ bool CNetworkInterfaceLinux::GetHostMacAddress(unsigned long host_ip, std::strin
       return true;
 
   return false;
-}
 #endif
+}
 
 std::vector<NetworkAccessPoint> CNetworkInterfaceLinux::GetAccessPoints(void)
 {

--- a/xbmc/network/linux/NetworkLinux.cpp
+++ b/xbmc/network/linux/NetworkLinux.cpp
@@ -83,13 +83,10 @@
 
 using namespace KODI::MESSAGING;
 
-CNetworkInterfaceLinux::CNetworkInterfaceLinux(CNetworkLinux* network, bool sa_ipv6, unsigned int ifa_flags,
-                                               std::string ifa_addr, std::string ifa_netmask, std::string interfaceName,
-                                               char interfaceMacAddrRaw[6]) :
-  m_interfaceIpv6(sa_ipv6),
+CNetworkInterfaceLinux::CNetworkInterfaceLinux(CNetworkLinux* network, unsigned int ifa_flags,
+                                               struct sockaddr *address, struct sockaddr *netmask,
+                                               std::string interfaceName, char interfaceMacAddrRaw[6]) :
   m_interfaceFlags(ifa_flags),
-  m_interfaceAddr(ifa_addr),
-  m_interfaceNetmask(ifa_netmask),
   m_removed(false),
   m_interfaceName(interfaceName),
   m_interfaceMacAdr(StringUtils::Format("%02X:%02X:%02X:%02X:%02X:%02X",
@@ -101,11 +98,17 @@ CNetworkInterfaceLinux::CNetworkInterfaceLinux(CNetworkLinux* network, bool sa_i
                                         (uint8_t)interfaceMacAddrRaw[5]))
 {
    m_network = network;
+  m_address = (struct sockaddr *) malloc(sizeof(struct sockaddr_storage));
+  m_netmask = (struct sockaddr *) malloc(sizeof(struct sockaddr_storage));
+  memcpy(m_address, address, sizeof(struct sockaddr_storage));
+  memcpy(m_netmask, netmask, sizeof(struct sockaddr_storage));
    memcpy(m_interfaceMacAddrRaw, interfaceMacAddrRaw, sizeof(m_interfaceMacAddrRaw));
 }
 
 CNetworkInterfaceLinux::~CNetworkInterfaceLinux(void)
 {
+  free(m_address);
+  free(m_netmask);
 }
 
 std::string& CNetworkInterfaceLinux::GetName(void)
@@ -143,8 +146,7 @@ bool CNetworkInterfaceLinux::IsConnected()
    unsigned int needFlags = IFF_RUNNING; //IFF_LOWER_UP
    bool iRunning = (m_interfaceFlags & needFlags) == needFlags;
 
-   // return only interfaces which has ip address
-   return iRunning && !m_interfaceAddr.empty();
+  return iRunning;
 }
 
 std::string CNetworkInterfaceLinux::GetMacAddress()
@@ -159,10 +161,7 @@ void CNetworkInterfaceLinux::GetMacAddressRaw(char rawMac[6])
 
 std::string CNetworkInterfaceLinux::GetCurrentIPAddress(void)
 {
-   std::string result;
-
-   result = m_interfaceAddr;
-   return result;
+   return CNetwork::GetIpStr(m_address);
 }
 
 std::string CNetworkInterfaceLinux::GetCurrentNetmask(void)
@@ -170,9 +169,9 @@ std::string CNetworkInterfaceLinux::GetCurrentNetmask(void)
    std::string result;
 
    if (isIPv4())
-     result = m_interfaceNetmask;
+    result = CNetwork::GetIpStr(m_netmask);
    else
-     result = StringUtils::Format("%d", CNetwork::PrefixLengthIPv6(m_interfaceNetmask));
+    result = StringUtils::Format("%u", CNetwork::PrefixLength(m_netmask));
    return result;
 }
 
@@ -398,7 +397,7 @@ void CNetworkLinux::GetMacAddress(struct ifaddrs *tif, char *mac)
 #endif
 }
 
-CNetworkInterfaceLinux *CNetworkLinux::Exists(const std::string &addr, const std::string &mask, const std::string &name)
+CNetworkInterfaceLinux *CNetworkLinux::Exists(const struct sockaddr *addr, const struct sockaddr *mask, const std::string &name)
 {
   for (auto &&iface: m_interfaces)
     if (((CNetworkInterfaceLinux*)iface)->Exists(addr, mask, name))
@@ -461,7 +460,7 @@ bool CNetworkLinux::queryInterfaceList()
      if(addr.empty() || mask.empty())
        continue;
 
-     CNetworkInterfaceLinux *iface = Exists(addr, mask, name);
+     CNetworkInterfaceLinux *iface = Exists(cur->ifa_addr, cur->ifa_netmask, name);
      if (iface)
      {
        iface->SetRemoved(false);
@@ -476,8 +475,8 @@ bool CNetworkLinux::queryInterfaceList()
      GetMacAddress(cur, macAddrRaw);
 #endif
 
-     CNetworkInterfaceLinux *i = new CNetworkInterfaceLinux(this, cur->ifa_addr->sa_family == AF_INET6,
-                                                            cur->ifa_flags, addr, mask, name, macAddrRaw);
+     CNetworkInterfaceLinux *i = new CNetworkInterfaceLinux(this, cur->ifa_flags, cur->ifa_addr,
+                                                            cur->ifa_netmask, name, macAddrRaw);
 
      m_interfaces.insert_after(pos, i);
      if (i->isIPv4())


### PR DESCRIPTION
- in `CNetworkInterfaceLinux` store the address and netmask as `struct sockaddr` instead of `std::string`
- add `CNetwork::PrefixLength`
- add `CNetwork::CompareAddresses`
- remove `CNetwork::PrefixLengthIPv6`
